### PR TITLE
Refactor/fix DAO nomenclature

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # SQLAlchemyFilter
-Filtered/paginated lists on DTO classes using SQLAlchemy.
+Filtered/paginated lists on DAO classes using SQLAlchemy.
 
 > This library was built with a specific use case in mind. Because of that, 
 > the structure required for this lib to work in a project is too 
@@ -14,13 +14,13 @@ pip install git+https://github.com/rahenrique/sqlalchemy-filter.git
 
 ## Usage
 
-Create a DTO Class to handle your data retrieving methods. In the following 
-example, we are creating a MyModel model, and a corresponding MyModelDTO 
+Create a DAO Class to handle your data retrieving methods. In the following 
+example, we are creating a MyModel model, and a corresponding MyModelDAO 
 repository class. In the repository class, we are extending from the 
-`FilteredListDTOMixin`, to inherit the `get_all_with_filters` method.
+`FilteredListDAOMixin`, to inherit the `get_all_with_filters` method.
 
 ```python
-from sqlalchemyfilter import FilteredListDTOMixin
+from sqlalchemyfilter import FilteredListDAOMixin
 from sqlalchemy import Column, Integer, String, select
 from sqlalchemy.orm import DeclarativeBase
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -32,7 +32,7 @@ class MyModel(DeclarativeBase):
     name_field = Column(String(30), nullable=False)
 
 
-class MyModelDTO(FilteredListDTOMixin):
+class MyModelDAO(FilteredListDAOMixin):
     """MyModel data transfer object implementation."""
     
     def __init__(self, session: AsyncSession) -> None:
@@ -45,7 +45,7 @@ class MyModelDTO(FilteredListDTOMixin):
 Later on, in a service or router class, we can query the repository to get the 
 list of records using filters and pagination out of the box:
 ```python
-result = await MyModelDTO(session).get_all_with_filters(
+result = await MyModelDAO(session).get_all_with_filters(
         page=1,
         page_size=10,
         filters=["name_field:ABC"],
@@ -74,7 +74,7 @@ async def get_my_models(
         filter_parameters: dict = Depends(common_filter_parameters)
         session: AsyncSession):
 
-    return await MyModelDTO(session).get_all_with_filters(
+    return await MyModelDAO(session).get_all_with_filters(
         page=filter_parameters.get("page"),
         page_size=filter_parameters.get("page_size"),
         filters=filter_parameters.get("filters"),

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 setup(
     name='SQLAlchemyFilter',
     version='0.0.1',
-    description='Filtered/paginated lists on DTO classes using SQLAlchemy',
+    description='Filtered/paginated lists on DAO classes using SQLAlchemy',
     author='Rah Henrique',
     author_email='rafael@rah.com.br',
     url='https://github.com/rahenrique/sqlalchemy-filter',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='SQLAlchemyFilter',
-    version='0.0.1',
+    version='0.0.2',
     description='Filtered/paginated lists on DAO classes using SQLAlchemy',
     author='Rah Henrique',
     author_email='rafael@rah.com.br',

--- a/sqlalchemyfilter/__init__.py
+++ b/sqlalchemyfilter/__init__.py
@@ -1,2 +1,2 @@
-from sqlalchemyfilter.models import FilteredListDTOMixin
+from sqlalchemyfilter.models import FilteredListDAOMixin
 from sqlalchemyfilter.utils import common_filter_parameters

--- a/sqlalchemyfilter/models.py
+++ b/sqlalchemyfilter/models.py
@@ -14,8 +14,8 @@ from sqlalchemy.sql import ColumnElement, Select, expression
 from sqlalchemy.sql.elements import UnaryExpression
 
 
-class FilteredListDTOMixin:
-    """Mixin for filtered / paginated list on DTO classes."""
+class FilteredListDAOMixin:
+    """Mixin for filtered / paginated list on DAO classes."""
 
     OPERATOR_EQUALS = '='
     OPERATOR_GREATER_THAN = '>'
@@ -191,12 +191,12 @@ class FilteredListDTOMixin:
             python_type = field_type.python_type
 
         operators = {
-            FilteredListDTOMixin.OPERATOR_EQUALS: {"bool": is_, "numeric": in_op, "string": ilike_op, "other": eq},
-            FilteredListDTOMixin.OPERATOR_GREATER_THAN: {"bool": None, "numeric": gt, "string": gt, "other": gt},
-            FilteredListDTOMixin.OPERATOR_GREATER_OR_EQUALS_THAN: {"bool": None, "numeric": ge, "string": ge,
+            FilteredListDAOMixin.OPERATOR_EQUALS: {"bool": is_, "numeric": in_op, "string": ilike_op, "other": eq},
+            FilteredListDAOMixin.OPERATOR_GREATER_THAN: {"bool": None, "numeric": gt, "string": gt, "other": gt},
+            FilteredListDAOMixin.OPERATOR_GREATER_OR_EQUALS_THAN: {"bool": None, "numeric": ge, "string": ge,
                                                                    "other": ge},  # NOQA
-            FilteredListDTOMixin.OPERATOR_LOWER_THAN: {"bool": None, "numeric": lt, "string": lt, "other": lt},
-            FilteredListDTOMixin.OPERATOR_LOWER_OR_EQUALS_THAN: {"bool": None, "numeric": le, "string": le,
+            FilteredListDAOMixin.OPERATOR_LOWER_THAN: {"bool": None, "numeric": lt, "string": lt, "other": lt},
+            FilteredListDAOMixin.OPERATOR_LOWER_OR_EQUALS_THAN: {"bool": None, "numeric": le, "string": le,
                                                                  "other": le},  # NOQA
         }
 


### PR DESCRIPTION
By a mistake, the DAO classes (Data Access Objects) were referenced as DTO (Data Transfer Objects).
This PR fixes the nomenclaure, and bumps the lib's minor version.